### PR TITLE
Enable logging by default

### DIFF
--- a/server/src/codeprober/util/SessionLogger.java
+++ b/server/src/codeprober/util/SessionLogger.java
@@ -49,8 +49,8 @@ public class SessionLogger {
 	}
 
 	private static File getLoggingDir() {
-		final String dirProp = System.getProperty("cpr.session_logger_dir");
-		if (dirProp == null) {
+		final String dirProp = System.getProperty("cpr.session_logger_dir", "logs");
+		if (dirProp == null || dirProp.equals("")) {
 			return null;
 		}
 		final File dir = new File(dirProp);


### PR DESCRIPTION
Enabled anonymous session logging by default to the directory "logs".

It can be disabled by explicitly setting the directory to an empty string. For example:
```
java -Dcpr.session_logger_dir="" -jar code-prober-dev.jar
```
You can tell that logging is enabled if you see a message like this during start:
```
Logging anonymous session data to logs/2023-12-05-14-19_1NzI5RTk
```
