### PR TITLE
Pull SessionLogger improvements from upstream, enabled by default

### DIFF
--- a/server/src/codeprober/CodeProber.java
+++ b/server/src/codeprober/CodeProber.java
@@ -62,7 +62,10 @@ public class CodeProber {
 
 		final SessionLogger sessionLogger = SessionLogger.init();
 		if (sessionLogger != null) {
-			System.out.println("Logging anonymous session data to " + sessionLogger.getTargetDirectory());
+			System.out.println("Logging anonymous session data to " + sessionLogger.getTargetPath());
+			sessionLogger.log(new JSONObject() //
+					.put("t", "Startup") //
+					.put("v", VersionInfo.getInstance().toString()));
 		}
 		final UnderlyingToolProxy underlyingTool = new UnderlyingToolProxy();
 		if (parsedArgs.jarPath != null) {
@@ -253,10 +256,10 @@ public class CodeProber {
 
 		final Runnable onSomeClientDisconnected = userFacingHandler::onOneOrMoreClientsDisconnected;
 		new Thread(() -> WebServer.start(parsedArgs, msgPusher, unwrappedHandler, onSomeClientDisconnected, needsTool,
-				setUnderlyingJarPath)).start();
+				setUnderlyingJarPath, sessionLogger)).start();
 		if (!WebSocketServer.shouldDelegateWebsocketToHttp() && WebSocketServer.getPort() != WebServer.getPort()) {
-			new Thread(() -> WebSocketServer.start(parsedArgs, msgPusher, topHandler, onSomeClientDisconnected))
-					.start();
+			new Thread(() -> WebSocketServer.start(parsedArgs, msgPusher, topHandler, onSomeClientDisconnected,
+					sessionLogger)).start();
 		} else if (WebSocketServer.shouldDelegateWebsocketToHttp()) {
 			System.out.println("Not starting websocket server, running requests over normal HTTP requests instead.");
 		} else {

--- a/server/src/codeprober/server/WebSocketServer.java
+++ b/server/src/codeprober/server/WebSocketServer.java
@@ -28,6 +28,7 @@ import codeprober.protocol.data.BackingFile;
 import codeprober.protocol.data.InitInfo;
 import codeprober.protocol.data.protocolgen_spec_InitInfo_1;
 import codeprober.util.ParsedArgs;
+import codeprober.util.SessionLogger;
 import codeprober.util.VersionInfo;
 
 public class WebSocketServer {
@@ -146,7 +147,7 @@ public class WebSocketServer {
 	}
 
 	static void handleRequest(Socket socket, ParsedArgs args, ServerToClientMessagePusher msgPusher,
-			Function<ClientRequest, JSONObject> onQuery, AtomicBoolean connectionIsAlive)
+			Function<ClientRequest, JSONObject> onQuery, AtomicBoolean connectionIsAlive, SessionLogger logger)
 			throws IOException, NoSuchAlgorithmException {
 		final InputStream in = socket.getInputStream();
 		@SuppressWarnings("resource")
@@ -155,11 +156,11 @@ public class WebSocketServer {
 		if (WebServer.handleAuthCookieRelatedRequest(data, socket.getInetAddress(), socket.getOutputStream())) {
 			return;
 		}
-		handleRequestWithPreparsedData(socket, args, msgPusher, onQuery, connectionIsAlive, data);
+		handleRequestWithPreparsedData(socket, args, msgPusher, onQuery, connectionIsAlive, data, logger);
 	}
 
 	static void handleRequestWithPreparsedData(Socket socket, ParsedArgs args, ServerToClientMessagePusher msgPusher,
-			Function<ClientRequest, JSONObject> onQuery, AtomicBoolean connectionIsAlive, String data)
+			Function<ClientRequest, JSONObject> onQuery, AtomicBoolean connectionIsAlive, String data, SessionLogger logger)
 			throws IOException, NoSuchAlgorithmException {
 		final InputStream in = socket.getInputStream();
 		final OutputStream out = socket.getOutputStream();
@@ -193,6 +194,11 @@ public class WebSocketServer {
 				msgPusher.addChangeListener(onJarChange);
 				final Runnable cleanup = () -> msgPusher.removeChangeListener(onJarChange);
 
+				if (logger != null) {
+					logger.log(new JSONObject() //
+							.put("t", "ClientConnected") //
+							.put("p", "ws"));
+				}
 				writeWsMessage(out, getInitMsg(args).toJSON().toString());
 
 				final Consumer<AsyncRpcUpdate> asyncMessageWriter = asyncMsg -> {
@@ -338,7 +344,7 @@ public class WebSocketServer {
 	}
 
 	public static void start(ParsedArgs args, ServerToClientMessagePusher msgPusher,
-			Function<ClientRequest, JSONObject> onQuery, Runnable onSomeClientDisconnected) {
+			Function<ClientRequest, JSONObject> onQuery, Runnable onSomeClientDisconnected, SessionLogger logger) {
 		final int port = getPort();
 		try (ServerSocket server = new ServerSocket(port, 0, null)) {
 			livePort = server.getLocalPort();
@@ -349,7 +355,7 @@ public class WebSocketServer {
 				new Thread(() -> {
 					final AtomicBoolean connectionIsAlive = new AtomicBoolean(true);
 					try {
-						handleRequest(s, args, msgPusher, onQuery, connectionIsAlive);
+						handleRequest(s, args, msgPusher, onQuery, connectionIsAlive, logger);
 					} catch (IOException | NoSuchAlgorithmException e) {
 						System.out.println("Error while handling request");
 						e.printStackTrace();

--- a/server/src/codeprober/util/SessionLogger.java
+++ b/server/src/codeprober/util/SessionLogger.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -20,10 +23,16 @@ import org.json.JSONObject;
 /**
  * Event logger that logs interactions during a CodeProber session. Is opt-in,
  * and doesn't send the data anywhere. Instead, data is written to your file
- * system. Specify a logging dir with "-Dcpr.session_logger_dir=dirname".
+ * system. Specify a logging path with "-Dcpr.session_logger_dir=path".
  * <p>
- * Will save logs in "dirname/sessionid/logname.json", where sessionid is
- * randomly generated, and logname is an incrementing counter.
+ * If path does *not* end with ".json", then SessionLogger will save logs in
+ * "path/sessionid/logname.json", where sessionid is randomly generated, and
+ * logname is an incrementing counter.
+ * <p>
+ * If path does end with ".json", then SessionLogger will append logs to a file
+ * with the specified path. This can be used to create a persistent log file
+ * across multiple sessions. Note however that this file will not be valid JSON,
+ * it will be a concatenation of several JSON arrays.
  * <p>
  * Logs are saved when {@link #AUTO_FLUSH_EVENT_COUNTER} events are met, or when
  * the user has been idle for {@link #AUTO_FLUSH_IDLE_TIME_MS}.
@@ -31,8 +40,10 @@ import org.json.JSONObject;
 public class SessionLogger {
 	private static final int AUTO_FLUSH_EVENT_COUNTER = 128;
 	private static final int AUTO_FLUSH_IDLE_TIME_MS = 10_000;
-	// Stop after 128 MB
-	private static long AUTO_STOP_DATA_THRESHOLD = 128 * 1024 * 1024;
+	private static final String PREFS_KEY_PERSISTENT_LOG_FILE = "cpr-session-log-path";
+	private static final boolean LOG_TO_SINGLE_FILE_BY_DEFAULT = false;
+	// Stop after 32 MB
+	private static long AUTO_STOP_DATA_THRESHOLD = 32 * 1024 * 1024;
 
 	static {
 		final String thresholdKey = "SESSION_LOGGER_DATA_LIMIT_KB";
@@ -48,33 +59,86 @@ public class SessionLogger {
 		}
 	}
 
-	private static File getLoggingDir() {
-		final String dirProp = System.getProperty("cpr.session_logger_dir");
-		if (dirProp == null) {
+	private static File getLoggingPath() {
+		String persistentLoggingFile = null;
+		if (LOG_TO_SINGLE_FILE_BY_DEFAULT) {
+			try {
+				final Preferences prefs = Preferences.userRoot();
+				persistentLoggingFile = prefs.get(PREFS_KEY_PERSISTENT_LOG_FILE, null);
+				if (persistentLoggingFile != null
+						&& (!persistentLoggingFile.startsWith("logs/L") || !persistentLoggingFile.endsWith(".json"))) {
+					System.out.printf("Unexpected persistent log file from preferences, discarding it. Old name: '%s'\n",
+							persistentLoggingFile);
+					persistentLoggingFile = null;
+				}
+				if (persistentLoggingFile != null) {
+					final File sizeCheck = new File(persistentLoggingFile);
+					if (sizeCheck.exists() && sizeCheck.length() > AUTO_STOP_DATA_THRESHOLD) {
+						// Quite unlikely, but if somebody uses CodeProber for a very long time on the
+						// same machine, with logging enabled, it could create a massive log file.
+						// Big files could be for example be rejected by git hosting providers, which is
+						// a problem. Solve the problem by generating a new log name.
+						System.out.printf(
+								"Persistent log file '%s' has grown quite large, leaving it as-is and generating a new log name\n",
+								persistentLoggingFile);
+					}
+				}
+				if (persistentLoggingFile == null) {
+					persistentLoggingFile = String.format("logs/L%s.json", generateRandomCharacters());
+					prefs.put(PREFS_KEY_PERSISTENT_LOG_FILE, persistentLoggingFile);
+					prefs.flush();
+				}
+			} catch (SecurityException | BackingStoreException e) {
+				System.out.println("Error reading/writing system preferences");
+				e.printStackTrace();
+			}
+		}
+		final String pathProp = System.getProperty("cpr.session_logger_dir", persistentLoggingFile);
+		if (pathProp == null || pathProp.equals("")) {
 			return null;
 		}
-		final File dir = new File(dirProp);
+		File dir = new File(pathProp);
+		final File ret = dir;
+		if (pathProp.endsWith(".json")) {
+			// It is not a directory, it is a file
+			dir = dir.getParentFile();
+			if (dir == null) {
+				// Root of file system, exit
+				return null;
+			}
+		}
 		if (!dir.exists() && !dir.mkdirs()) {
-			System.out.println("Couldn't create logging dir '" + dirProp + "', perhaps permission problems?");
+			System.out.println("Couldn't create logging dir '" + pathProp + "', perhaps permission problems?");
 			return null;
 		}
-		return dir;
+		return ret;
+	}
+
+	private static String generateRandomCharacters() {
+		return generateRandomCharacters(8);
+	}
+
+	private static String generateRandomCharacters(int limit) {
+		String ret = Base64.getEncoder().withoutPadding()
+				.encodeToString(((Math.random() * Integer.MAX_VALUE) + "_" + (Math.random() * Integer.MAX_VALUE))
+						.getBytes(StandardCharsets.UTF_8));
+		if (ret.length() > limit) {
+			ret = ret.substring(ret.length() - limit, ret.length());
+		}
+		return ret;
 	}
 
 	public static SessionLogger init() {
-		final File dir = getLoggingDir();
-		if (dir == null) {
+		final File path = getLoggingPath();
+		if (path == null) {
 			return null;
 		}
-		final String subHead = new SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.ENGLISH).format(new Date()) + "_";
-		String subTail = Base64.getEncoder().withoutPadding()
-				.encodeToString(((Math.random() * Integer.MAX_VALUE) + "_" + (Math.random() * Integer.MAX_VALUE))
-						.getBytes(StandardCharsets.UTF_8));
-		if (subTail.length() > 8) {
-			subTail = subTail.substring(subTail.length() - 8, subTail.length());
+		if (path.getName().endsWith(".json")) {
+			return new SessionLogger(path);
 		}
-
-		final File sub = new File(dir, subHead + subTail);
+		final File sub = new File(path,
+				String.format("%s_%s", new SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.ENGLISH).format(new Date()),
+						generateRandomCharacters()));
 		if (!sub.mkdir()) {
 			System.err.println(
 					"Couldn't create logging sub-dir '" + sub.getAbsolutePath() + "', perhaps permission problems?");
@@ -85,7 +149,7 @@ public class SessionLogger {
 
 	}
 
-	private final File dir;
+	private final File targetPath;
 	private final List<JSONObject> pendingEvents = new ArrayList<>();
 
 	private final AtomicInteger flushFileNameGen = new AtomicInteger(0);
@@ -93,15 +157,17 @@ public class SessionLogger {
 	private AtomicBoolean stop = new AtomicBoolean(false);
 	private final AutoFlusher flusher;
 	private long numLoggedBytes = 0L;
+	private String sessionId;
 
-	private SessionLogger(File dir) {
-		this.dir = dir;
+	private SessionLogger(File dirOrFile) {
+		this.targetPath = dirOrFile;
+		this.sessionId = generateRandomCharacters(4);
 		this.flusher = new AutoFlusher();
 		this.flusher.start();
 	}
 
-	public File getTargetDirectory() {
-		return dir;
+	public File getTargetPath() {
+		return targetPath;
 	}
 
 	public void log(JSONObject data) {
@@ -111,6 +177,7 @@ public class SessionLogger {
 
 		final JSONObject wrapper = new JSONObject();
 		wrapper.put("t", System.currentTimeMillis());
+		wrapper.put("s", sessionId);
 		wrapper.put("d", data);
 
 		synchronized (SessionLogger.this) {
@@ -145,7 +212,17 @@ public class SessionLogger {
 			pendingEvents.clear();
 			lastEventNanos = System.nanoTime();
 		}
-		final File dst = new File(dir, String.format("%04d.json", flushFileNameGen.getAndIncrement()));
+		final File dst;
+		final OpenOption[] writeOptions;
+		if (targetPath.getName().endsWith(".json")) {
+			// Just append to the file
+			dst = targetPath;
+			writeOptions = new StandardOpenOption[] { StandardOpenOption.CREATE, StandardOpenOption.APPEND };
+		} else {
+			// Create new file
+			dst = new File(targetPath, String.format("%04d.json", flushFileNameGen.getAndIncrement()));
+			writeOptions = new StandardOpenOption[] { StandardOpenOption.CREATE_NEW };
+		}
 		if (!dst.getParentFile().exists()) {
 			// We _could_ recover here by recreating the directory.
 			// However, the safe choice is to interpret the deletion of the dir as a signal
@@ -156,9 +233,9 @@ public class SessionLogger {
 			return;
 		}
 		try {
-			final byte[] data = arr.toString().getBytes(StandardCharsets.UTF_8);
+			final byte[] data = (arr.toString() + "\n").getBytes(StandardCharsets.UTF_8);
 			numLoggedBytes += data.length;
-			Files.write(dst.toPath(), data, StandardOpenOption.CREATE_NEW);
+			Files.write(dst.toPath(), data, writeOptions);
 		} catch (IOException e) {
 			System.err.println("SessionLogger: Error when flushing events to " + dst + ". Stopping.");
 			e.printStackTrace();

--- a/server/src/codeprober/util/SessionLogger.java
+++ b/server/src/codeprober/util/SessionLogger.java
@@ -41,7 +41,7 @@ public class SessionLogger {
 	private static final int AUTO_FLUSH_EVENT_COUNTER = 128;
 	private static final int AUTO_FLUSH_IDLE_TIME_MS = 10_000;
 	private static final String PREFS_KEY_PERSISTENT_LOG_FILE = "cpr-session-log-path";
-	private static final boolean LOG_TO_SINGLE_FILE_BY_DEFAULT = false;
+	private static final boolean LOG_TO_SINGLE_FILE_BY_DEFAULT = true;
 	// Stop after 32 MB
 	private static long AUTO_STOP_DATA_THRESHOLD = 32 * 1024 * 1024;
 


### PR DESCRIPTION
Pulled in "Improvements to SessionLogger" from the lu-cs-sde/codeprober repo.
Changed LOG_TO_SINGLE_FILE_BY_DEFAULT to true.

SessionLogger will now log to a single consistent file, even across multiple CodeProber sessions.